### PR TITLE
[TASK] add new option for configuration

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -17,6 +17,7 @@ class Configuration
         $this->allowedTypes = (string)($configuration['allowedTypes'] ?? '');
         $this->headerComment = (bool)($configuration['headerComment'] ?? true);
         $this->removeComments = (bool)($configuration['removeComments'] ?? false);
+        $this->removeOmittedQuotes = (bool)($configuration['removeOmittedQuotes'] ?? false);
     }
 
     /** @var bool */
@@ -30,6 +31,9 @@ class Configuration
 
     /** @var bool */
     protected $removeComments = false;
+
+    /** @var bool */
+    protected $removeOmittedQuotes = false;
 
     public function enabled(): bool
     {
@@ -52,6 +56,14 @@ class Configuration
     public function removeComments(): bool
     {
         return $this->removeComments;
+    }
+
+    /**
+     * @return bool
+     */
+    public function removeOmittedQuotes(): bool
+    {
+        return $this->removeOmittedQuotes;
     }
 
 }

--- a/Classes/Hooks/HtmlMinHook.php
+++ b/Classes/Hooks/HtmlMinHook.php
@@ -36,6 +36,7 @@ class HtmlMinHook
     {
         $htmlMin = new HtmlMin();
         $htmlMin->doRemoveComments($this->configuration->removeComments());
+        $htmlMin->doRemoveOmittedQuotes($this->configuration->removeOmittedQuotes());
         $frontendController->content = $htmlMin->minify($frontendController->content);
 
         $headerComment = $frontendController->config['config']['headerComment'] ?? '';

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -9,3 +9,6 @@ headerComment = 1
 
 # cat=features/enable/3; type=boolean; label=Remove all comments:If set, all comments are stripped which might be useful for indexing
 removeComments = 0
+
+# cat=features/enable/4; type=boolean; label=Remove quotes:If set, quotes with single values will be removed. e.g. class="lall" => class=lall
+removeOmittedQuotes = 0


### PR DESCRIPTION
add new configuration option to prevent removing quotes from attributes with single values due to accessibility issues. the reason is, that aria-label=false will not work in screenreaders.