### PR TITLE
[TASK] reposition LF and indent for header comment

### DIFF
--- a/Classes/Hooks/HtmlMinHook.php
+++ b/Classes/Hooks/HtmlMinHook.php
@@ -41,7 +41,7 @@ class HtmlMinHook
 
         $headerComment = $frontendController->config['config']['headerComment'] ?? '';
         if ($headerComment && $this->configuration->headerComment()) {
-            $headerComment = '<!--' . $headerComment . $this->getTypo3Information() . LF . '-->';
+            $headerComment = '<!--' . LF . '	' . $headerComment . LF . $this->getTypo3Information() . '-->';
             $frontendController->content = str_replace('<title>', $headerComment . LF . '<title>', $frontendController->content);
         }
     }


### PR DESCRIPTION
Reposition the linefeed and indents in case an individual TYPO3 header comment is used, resulting in a nicer display in line with the default TYPO3 header comment.