### PR TITLE
[TASK] add new option for configuration

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -18,6 +18,7 @@ class Configuration
         $this->headerComment = (bool)($configuration['headerComment'] ?? true);
         $this->removeComments = (bool)($configuration['removeComments'] ?? false);
         $this->removeOmittedQuotes = (bool)($configuration['removeOmittedQuotes'] ?? false);
+        $this->removeOmittedHtmlTags = (bool)($configuration['removeOmittedHtmlTags'] ?? false);
     }
 
     /** @var bool */
@@ -34,6 +35,9 @@ class Configuration
 
     /** @var bool */
     protected $removeOmittedQuotes = false;
+
+    /** @var bool */
+    protected $removeOmittedHtmlTags = false;
 
     public function enabled(): bool
     {
@@ -66,4 +70,11 @@ class Configuration
         return $this->removeOmittedQuotes;
     }
 
+    /**
+     * @return bool
+     */
+    public function removeOmittedHtmlTags(): bool
+    {
+        return $this->removeOmittedHtmlTags;
+    }
 }

--- a/Classes/Hooks/HtmlMinHook.php
+++ b/Classes/Hooks/HtmlMinHook.php
@@ -37,6 +37,7 @@ class HtmlMinHook
         $htmlMin = new HtmlMin();
         $htmlMin->doRemoveComments($this->configuration->removeComments());
         $htmlMin->doRemoveOmittedQuotes($this->configuration->removeOmittedQuotes());
+        $htmlMin->doRemoveOmittedHtmlTags($this->configuration->removeOmittedHtmlTags());
         $frontendController->content = $htmlMin->minify($frontendController->content);
 
         $headerComment = $frontendController->config['config']['headerComment'] ?? '';

--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,9 @@ The following settings can be defined in the *Install Tool > Settings*:
 
 - `enable`: Enable/Disable the usage of the extension
 - `headerComment`: If set, the header comment will be keep intact.
+- `removeComments`: If set, all comments are stripped which might be useful for indexing
+- `removeOmittedQuotes`: If set, quotes with single values will be removed. e.g. class="lall" => class=lall
+- `removeOmittedHtmlTags`: If set, ommitted html tags will be removed e.g. <p>lall</p> => <p>lall
 
 
 ## Credits

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -12,3 +12,6 @@ removeComments = 0
 
 # cat=features/enable/4; type=boolean; label=Remove quotes:If set, quotes with single values will be removed. e.g. class="lall" => class=lall
 removeOmittedQuotes = 0
+
+# cat=features/enable/5; type=boolean; label=Remove omitted HTML Tags:If set, ommitted html tags will be removed e.g. <p>lall</p> => <p>lall
+removeOmittedHtmlTags = 0


### PR DESCRIPTION
add new configuration option to prevent removing quotes from attributes with single values due to accessibility issues. the reason is, that aria-label=false will not work in screenreaders.

add new configuration option to prevent removing omitted html tags. in some cases this might be usefull - eg. when having whitespaces at the end of paragraphs when you dont want it.